### PR TITLE
Replace split by explode

### DIFF
--- a/GMaps.php
+++ b/GMaps.php
@@ -101,7 +101,7 @@ class GMaps
         if (! empty($xml->Response)) {
             $point= $xml->Response->Placemark->Point;
             if (! empty($point)) {
-                $coordinatesSplit = split(",", $point->coordinates);
+                $coordinatesSplit = explode(",", $point->coordinates);
                 // Format: Longitude, Latitude, Altitude
                 $this->_latitude = $coordinatesSplit[1];
                 $this->_longitude = $coordinatesSplit[0];    


### PR DESCRIPTION
Hi there!

I was using your code to practice PHP + Google Maps, and there was an annoying warning on my screen, regarding the deprecation of split in PHP 5.3. 

I've replaced it by explode. Hope you find it useful.

Thank you for sharing this code!
Bests, Bruno.
